### PR TITLE
Kappa parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.idea
+pip-selfcheck.json
+bin
+lib
+include

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .idea
+.Python
 pip-selfcheck.json
 bin
 lib
+share
 include
+*.pyc

--- a/harness/kappa_parser/ast.py
+++ b/harness/kappa_parser/ast.py
@@ -1,12 +1,10 @@
-from __future__ import unicode_literals
-
 from functools import total_ordering
 from abc import ABCMeta
 
 
 def _assert_all_is_instance(iterable, klass):
     for o in iterable:
-        assert isinstance(o, klass), o
+        assert isinstance(o, klass), repr(o)
 
 
 class ASTBase(object):
@@ -28,14 +26,11 @@ class ASTBase(object):
         assert type(self) == type(other)  # generally we don't want allow cross-classes comparisons
         return self.__dict__.items() < other.__dict__.items()
 
-    def __unicode__(self):
+    def __str__(self):
         items = self.__dict__.items()
         attrs = ' '.join('%s=%s' % (attr, val) for attr, val in items)
         type_name = type(self).__name__
         return '<%s %s>' % (type_name, attrs) if attrs else "<%s>" % type_name
-
-    def __str__(self):
-        return unicode(self).encode()
 
     def __repr__(self):
         return str(self)
@@ -66,9 +61,9 @@ class Link(LinkP):
     def __init__(self, text):
         """
         :param text: annotation for a link
-        :type text: unicode
+        :type text: str
         """
-        assert isinstance(text, unicode)
+        assert isinstance(text, str)
         self.text = text
 
 
@@ -83,9 +78,9 @@ class State(StateP):
     def __init__(self, text):
         """
         :param text: annoutation for a state
-        :type text: unicode
+        :type text: str
         """
-        assert isinstance(text, unicode), text
+        assert isinstance(text, str), text
         self.text = text
 
 
@@ -117,14 +112,14 @@ class AgentP(ASTBase):
     def __init__(self, name, sites):
         """
         :param name: agent's human-readable name
-        :type name: unicode
+        :type name: str
 
         :param sites: mapping between site names and sites
-        :type sites: dict[unicode, SiteP]
+        :type sites: dict[str, SiteP]
         """
-        assert isinstance(name, unicode), name
+        assert isinstance(name, str), name
         assert isinstance(sites, dict)
-        _assert_all_is_instance(sites.keys(), unicode)
+        _assert_all_is_instance(sites.keys(), str)
         _assert_all_is_instance(sites.values(), SiteP)
         self.name = name
         self.sites = sites
@@ -146,15 +141,15 @@ class AgentD(ASTBase):
     def __init__(self, name, sites):
         """
         :param name: human-readable name of an agent
-        :type name: unicode
+        :type name: str
         :param sites: mapping between site names of an agent and their possible values
-        :type sites: dict[unicode, tuple[unicode]]
+        :type sites: dict[str, tuple[str]]
         """
-        assert isinstance(name, unicode), name
-        _assert_all_is_instance(sites.keys(), unicode)
+        assert isinstance(name, str), name
+        _assert_all_is_instance(sites.keys(), str)
         for site in sites.values():
             assert isinstance(site, tuple), tuple
-            _assert_all_is_instance(site, unicode)
+            _assert_all_is_instance(site, str)
         self.name = name
         self.sites = sites
 
@@ -174,9 +169,9 @@ class Var(Expr):
     def __init__(self, name):
         """
         :param name: variable's name
-        :type name: unicode
+        :type name: str
         """
-        assert isinstance(name, unicode), name
+        assert isinstance(name, str), name
         self.name = name
 
 
@@ -284,12 +279,12 @@ class TokE(ASTBase):
     def __init__(self, name, expr):
         """
         :param name: token's name
-        :type name: unicode
+        :type name: str
 
         :param expr: token's expressions
         :type expr: Expr
         """
-        assert isinstance(name, unicode), name
+        assert isinstance(name, str), name
         assert isinstance(expr, Expr), expr
         self.name = name
         self.expr = expr
@@ -318,12 +313,12 @@ class Rule(ASTBase):
         :type rate_c: Expr
 
         :param desc: rule human-readable description
-        :type desc: unicode
+        :type desc: str
         """
         # TODO: type validation for lhs and rhs
         assert isinstance(rate, Expr), rate
         assert isinstance(rate_c, Expr), rate_c
-        assert isinstance(desc, unicode), desc
+        assert isinstance(desc, str), desc
         self.lhs = lhs
         self.rhs = rhs
         self.rate = rate
@@ -336,12 +331,12 @@ class VarD(ASTBase):
     def __init__(self, name, expr):
         """
         :param name: name of a variable
-        :type name: unicode
+        :type name: str
 
         :param expr: expression to bind to variable
         :type expr: Expr
         """
-        assert isinstance(name, unicode), name
+        assert isinstance(name, str), name
         assert isinstance(expr, Expr), name
         self.name = name
         self.expr = expr
@@ -352,9 +347,9 @@ class TokD(ASTBase):
     def __init__(self, name):
         """
         :param name: token's name
-        :type name: unicode
+        :type name: str
         """
-        assert isinstance(name, unicode), unicode
+        assert isinstance(name, str), str
         self.name = name
 
 
@@ -363,12 +358,12 @@ class Obs(ASTBase):
     def __init__(self, name, pattern):
         """
         :param name: name of an observation
-        :type name: unicode
+        :type name: str
 
         :param pattern: pattern to observe
         :type pattern: AgentP
         """
-        assert isinstance(name, unicode), name
+        assert isinstance(name, str), name
         assert isinstance(pattern, AgentP), pattern
         self.pattern = pattern
 
@@ -480,7 +475,7 @@ class RDF(Statement):
     def __init__(self, value):
         """
         :param value: annotation text
-        :type value: unicode
+        :type value: str
         """
-        assert isinstance(value, unicode), value
+        assert isinstance(value, str), value
         self.value = value

--- a/harness/kappa_parser/ast.py
+++ b/harness/kappa_parser/ast.py
@@ -1,0 +1,486 @@
+from __future__ import unicode_literals
+
+from functools import total_ordering
+from abc import ABCMeta
+
+
+def _assert_all_is_instance(iterable, klass):
+    for o in iterable:
+        assert isinstance(o, klass), o
+
+
+class ASTBase(object):
+    """
+    Just providing a value semantics to all inheriting AST elements
+    """
+    __metaclass__ = ABCMeta
+
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return hash(self.__dict__.items())
+
+    def __lt__(self, other):
+        assert type(self) == type(other)  # generally we don't want allow cross-classes comparisons
+        return self.__dict__.items() < other.__dict__.items()
+
+    def __unicode__(self):
+        items = self.__dict__.items()
+        attrs = ' '.join('%s=%s' % (attr, val) for attr, val in items)
+        type_name = type(self).__name__
+        return '<%s %s>' % (type_name, attrs) if attrs else "<%s>" % type_name
+
+    def __str__(self):
+        return unicode(self).encode()
+
+    def __repr__(self):
+        return str(self)
+
+
+# data LinkP   = Bound | Unbound | MaybeBound | Link Text deriving (Eq, Ord)
+class LinkP(ASTBase):
+    # TODO: implement proper ordering
+    pass
+
+
+class BoundLink(LinkP):
+    pass
+BoundLink = BoundLink()  # Fancy way to make it something like singleton. Lets see how will it work.
+
+
+class UnboundLink(LinkP):
+    pass
+UnboundLink = UnboundLink()
+
+
+class MaybeBoundLink(LinkP):
+    pass
+MaybeBoundLink = MaybeBoundLink()
+
+
+class Link(LinkP):
+    def __init__(self, text):
+        """
+        :param text: annotation for a link
+        :type text: unicode
+        """
+        assert isinstance(text, unicode)
+        self.text = text
+
+
+# data StateP  = State Text | Undefined deriving (Eq, Ord)
+
+class StateP(ASTBase):
+    # TODO: implement proper ordering
+    pass
+
+
+class State(StateP):
+    def __init__(self, text):
+        """
+        :param text: annoutation for a state
+        :type text: unicode
+        """
+        assert isinstance(text, unicode), text
+        self.text = text
+
+
+class UndefinedState(StateP):
+    pass
+UndefinedState = UndefinedState()
+
+
+# type SiteP   = (LinkP, StateP)
+@total_ordering
+class SiteP(ASTBase):
+    def __init__(self, link, state):
+        """
+        :param link: link state of a site
+        :type link: LinkP
+
+        :param state: internal state of a site
+        :type state: StateP
+        """
+        assert isinstance(link, LinkP), link
+        assert isinstance(state, StateP), state
+        self.link = link
+        self.state = state
+
+
+# data AgentP  = AgentP Text (HashMap Text SiteP) deriving(Eq)
+@total_ordering
+class AgentP(ASTBase):
+    def __init__(self, name, sites):
+        """
+        :param name: agent's human-readable name
+        :type name: unicode
+
+        :param sites: mapping between site names and sites
+        :type sites: dict[unicode, SiteP]
+        """
+        assert isinstance(name, unicode), name
+        assert isinstance(sites, dict)
+        _assert_all_is_instance(sites.keys(), unicode)
+        _assert_all_is_instance(sites.values(), SiteP)
+        self.name = name
+        self.sites = sites
+
+    def __lt__(self, other):
+        """
+        :type other: AgentP
+        :rtype: bool
+        """
+        return (self.name, self.sites.items()) < (other.name, other.sites.items())
+
+
+# data AgentD = AgentD Text (HashMap Text [Text]) deriving(Eq)
+@total_ordering
+class AgentD(ASTBase):
+    """
+    Agent definition
+    """
+    def __init__(self, name, sites):
+        """
+        :param name: human-readable name of an agent
+        :type name: unicode
+        :param sites: mapping between site names of an agent and their possible values
+        :type sites: dict[unicode, tuple[unicode]]
+        """
+        assert isinstance(name, unicode), name
+        _assert_all_is_instance(sites.keys(), unicode)
+        for site in sites.values():
+            assert isinstance(site, tuple), tuple
+            _assert_all_is_instance(site, unicode)
+        self.name = name
+        self.sites = sites
+
+    def __lt__(self, other):
+        """
+        :type other: AgentD
+        :rtype: bool
+        """
+        return (self.name, sorted(self.sites.items())) < (other.name, sorted(other.sites.items()))
+
+
+class Expr(ASTBase):
+    __metaclass__ = ABCMeta
+
+
+class Var(Expr):
+    def __init__(self, name):
+        """
+        :param name: variable's name
+        :type name: unicode
+        """
+        assert isinstance(name, unicode), name
+        self.name = name
+
+
+class Lit(Expr):
+    def __init__(self, value):
+        """
+        :param value: numeric literal's value
+        :type value: float
+        """
+        assert isinstance(value, float), value
+        self.value = value
+
+
+class UnaryCompositeExpr(Expr):
+    def __init__(self, expr):
+        """
+        :param expr: expression to wrap
+        :type expr: Expr
+        """
+        assert isinstance(expr, Expr), expr
+        self.expr = expr
+
+
+class Neg(UnaryCompositeExpr):
+    pass
+
+
+class Abs(UnaryCompositeExpr):
+    pass
+
+
+class Floor(UnaryCompositeExpr):
+    pass
+
+
+class Exp(UnaryCompositeExpr):
+    pass
+
+
+class Cos(UnaryCompositeExpr):
+    pass
+
+
+class Sin(UnaryCompositeExpr):
+    pass
+
+
+class Tan(UnaryCompositeExpr):
+    pass
+
+
+class Log(UnaryCompositeExpr):
+    pass
+
+
+class BinaryCompositeExpr(Expr):
+    def __init__(self, lhs, rhs):
+        """
+        :param lhs: left operand
+        :type lhs: Expr
+
+        :param rhs: right operana
+        :type rhs: Expr
+        """
+        assert isinstance(lhs, Expr), lhs
+        assert isinstance(rhs, Expr), rhs
+        self.lhs = lhs
+        self.rhs = rhs
+
+
+class Min(BinaryCompositeExpr):
+    pass
+
+
+class Max(BinaryCompositeExpr):
+    pass
+
+
+class Plus(BinaryCompositeExpr):
+    pass
+
+
+class Minus(BinaryCompositeExpr):
+    pass
+
+
+class Times(BinaryCompositeExpr):
+    pass
+
+
+class Pow(BinaryCompositeExpr):
+    pass
+
+
+class Div(BinaryCompositeExpr):
+    pass
+
+
+class Mod(BinaryCompositeExpr):
+    pass
+
+
+# data TokE    = Tok Text Expr deriving(Show, Eq, Ord)
+class TokE(ASTBase):
+    def __init__(self, name, expr):
+        """
+        :param name: token's name
+        :type name: unicode
+
+        :param expr: token's expressions
+        :type expr: Expr
+        """
+        assert isinstance(name, unicode), name
+        assert isinstance(expr, Expr), expr
+        self.name = name
+        self.expr = expr
+
+
+# data Rule = Rule { lhs:: ([AgentP], [TokE])
+#                  , rhs:: ([AgentP], [TokE])
+#                  , rate:: Expr
+#                  , rateC:: Expr
+#                  , desc:: Text
+#                  }
+# deriving(Show, Eq)
+class Rule(ASTBase):
+    def __init__(self, lhs, rhs, rate, rate_c=Lit(0.0), desc=""):
+        """
+        :param lhs: origin part of a rule
+        :type lhs: tuple[tuple[AgentP], tuple[TokE]] | None
+
+        :param rhs: result part of a rule
+        :type rhs: tuple[tuple[AgentP], tuple[TokE]] | None
+
+        :param rate: rate of a rule
+        :type rate: Expr
+
+        :param rate_c: ???
+        :type rate_c: Expr
+
+        :param desc: rule human-readable description
+        :type desc: unicode
+        """
+        # TODO: type validation for lhs and rhs
+        assert isinstance(rate, Expr), rate
+        assert isinstance(rate_c, Expr), rate_c
+        assert isinstance(desc, unicode), desc
+        self.lhs = lhs
+        self.rhs = rhs
+        self.rate = rate
+        self.rate_c = rate_c
+        self.desc = desc
+
+
+# data VarD = VarD Text Expr deriving (Show, Eq, Ord)
+class VarD(ASTBase):
+    def __init__(self, name, expr):
+        """
+        :param name: name of a variable
+        :type name: unicode
+
+        :param expr: expression to bind to variable
+        :type expr: Expr
+        """
+        assert isinstance(name, unicode), name
+        assert isinstance(expr, Expr), name
+        self.name = name
+        self.expr = expr
+
+
+# data TokD = TokD Text deriving (Show, Eq, Ord)
+class TokD(ASTBase):
+    def __init__(self, name):
+        """
+        :param name: token's name
+        :type name: unicode
+        """
+        assert isinstance(name, unicode), unicode
+        self.name = name
+
+
+# data Obs  = Obs Text AgentP deriving (Show, Eq, Ord)
+class Obs(ASTBase):
+    def __init__(self, name, pattern):
+        """
+        :param name: name of an observation
+        :type name: unicode
+
+        :param pattern: pattern to observe
+        :type pattern: AgentP
+        """
+        assert isinstance(name, unicode), name
+        assert isinstance(pattern, AgentP), pattern
+        self.pattern = pattern
+
+
+# data Init = Init Double [AgentP] deriving (Show, Eq, Ord)
+class Init(ASTBase):
+    def __init__(self, value, patterns):
+        """
+        :param value: initial value
+        :type value: float
+
+        :param patterns: agent patterns
+        :type patterns: tuple[AgentP]
+        """
+        assert isinstance(value, float), value
+        for p in patterns:
+            assert isinstance(p, AgentP), p
+        self.value = value
+        self.patterns = patterns
+
+
+# data Statement = AD AgentD | VD VarD | TD TokD | RD Rule | OB Obs | IN Init | RDF Text
+class Statement(ASTBase):
+    __metaclass__ = ABCMeta
+
+
+class AD(Statement):
+    """
+    Agent declaration
+    """
+    def __init__(self, agent):
+        """
+        :param agent: declared agent
+        :type agent: AgentD
+        """
+        assert isinstance(agent, AgentD), agent
+        self.agent = agent
+
+
+class VD(Statement):
+    """
+    Variable declaration
+    """
+    def __init__(self, var):
+        """
+        :param var: declared variable
+        :type var: VarD
+        """
+        assert isinstance(var, VarD), var
+        self.var = var
+
+
+class TD(Statement):
+    """
+    Token declaration
+    """
+    def __init__(self, tok):
+        """
+        :param tok: declared token
+        :type tok: TokD
+        """
+        assert isinstance(tok, TokD), tok
+        self.tok = tok
+
+
+class RD(Statement):
+    """
+    Rule declaration
+    """
+    def __init__(self, rule):
+        """
+        :param rule: declared rule
+        :type rule: Rule
+        """
+        assert isinstance(rule, Rule), rule
+        self.rule = rule
+
+
+class OB(Statement):
+    """
+    Observation declaration
+    """
+    def __init__(self, obs):
+        """
+        :param obs: declared observation
+        :type obs: Obs
+        """
+        assert isinstance(obs, Obs), obs
+        self.obs = obs
+
+
+class IN(Statement):
+    """
+    Init value declaration
+    """
+    def __init__(self, init):
+        """
+        :param init: declared init value
+        :type init: Init
+        """
+        assert isinstance(init, Init), init
+        self.init = init
+
+
+class RDF(Statement):
+    """
+    RDF annotation
+    """
+    def __init__(self, value):
+        """
+        :param value: annotation text
+        :type value: unicode
+        """
+        assert isinstance(value, unicode), value
+        self.value = value

--- a/harness/kappa_parser/parser.py
+++ b/harness/kappa_parser/parser.py
@@ -1,8 +1,10 @@
-from __future__ import unicode_literals, absolute_import, print_function
+from __future__ import absolute_import, print_function
 
 from pyparsing import *
 
 from . import ast
+
+ParserElement.enablePackrat()
 
 # Utility parser -- consume 0 or more whitespaces
 many_space = Optional(White()).suppress()

--- a/harness/kappa_parser/parser.py
+++ b/harness/kappa_parser/parser.py
@@ -1,0 +1,234 @@
+from __future__ import unicode_literals, absolute_import, print_function
+
+from pyparsing import *
+
+from . import ast
+
+# Utility parser -- consume 0 or more whitespaces
+many_space = Optional(White()).suppress()
+
+# Utility parser -- parse a floating point number
+double = Combine(Optional(Literal("-")) + Word(nums) + Optional(Literal(".") + Word(nums)))\
+    .setParseAction(lambda toks: float(toks[0]))
+
+# Utility parser -- parse a token/name
+tok = Combine(Word(alphas, exact=1) + Optional(Word(alphanums + "_+-")))
+
+# Utility parser -- parse a single-quoted token/name
+qtok = Suppress("'") + tok + Suppress("'")
+
+# Utility parser -- parse a state token
+stok = Word(alphanums + "_+-")
+
+# Utility parser -- parse a single-quoted string
+qstr = Suppress("'") + CharsNotIn("'") + Suppress("'")
+
+# Utility parser -- eat a comment until end of line
+comment = Suppress("#") + (lineEnd ^ (CharsNotIn("^\r\n", exact=1) + SkipTo(lineEnd))).suppress()
+
+# Utility parser -- eat up until end of line
+eol = (many_space + comment) ^ lineEnd.suppress()
+
+bare_site_sig = tok.copy().setParseAction(lambda toks: (toks[0], ()))
+
+ils_site_sig = And([tok, Suppress("~"), delimitedList(stok, delim="~", combine=True)])\
+    .setParseAction(lambda toks: (toks[0], tuple(toks[1].split("~"))))
+
+site_sig = bare_site_sig ^ ils_site_sig
+
+# AgentD
+agent_sig = And([tok, Suppress("("), Group(delimitedList(site_sig, delim=",")), Suppress(")")])\
+    .setParseAction(lambda toks: ast.AgentD(toks[0], dict(list(toks[1]))))
+
+# Statement
+agent_dec = (Suppress("%agent:") + many_space + agent_sig).setParseAction(lambda toks: ast.AD(toks[0]))
+
+# Statement
+tok_dec = Suppress("%token:") + many_space + qtok.copy().setParseAction(lambda toks: ast.TD(ast.TokD(toks[0])))
+
+expr = Forward()
+
+# Statement
+var_dec = (Literal("%var:").suppress() + many_space + qtok + many_space + expr) \
+    .setParseAction(lambda toks: ast.VD(ast.VarD(toks[0], toks[1])))
+
+
+e_var = qtok.copy().setParseAction(lambda toks: ast.Var(toks[0]))
+
+e_lit = double.copy().addParseAction(lambda toks: ast.Lit(toks[0]))
+
+e_bracket = Suppress("(") + many_space + expr + many_space + Suppress(")")
+
+e_neg = (Suppress("-") + expr).setParseAction(lambda toks: ast.Neg(toks[0]))
+
+
+def e_op(op, op_token):
+    """
+    :param op: AST operator, must be subclass of ast.UnaryCompositeExpr
+    :type op: type
+
+    :param op_token: text representation of this operand
+    :type op_token: unicode
+
+    :return: parser for this operator
+    :rtype: ParserElement
+    """
+    assert issubclass(op, ast.UnaryCompositeExpr)
+    return (Suppress(op_token) + expr).setParseAction(lambda toks: op(toks[0]))
+
+
+def e_binop(op, op_token):
+    """
+    :param op: AST operator, must be subclass of ast.UnaryCompositeExpr
+    :type op: type
+
+    :param op_token: text representation of this operand
+    :type op_token: unicode
+
+    :return: parser for this operator
+    :rtype: ParserElement
+    """
+    assert issubclass(op, ast.BinaryCompositeExpr)
+    return And([Suppress(op_token), Suppress("("), many_space, expr, many_space, Suppress(","),
+                many_space, expr, many_space, Suppress(")")]).setParseAction(lambda toks: op(toks[0], toks[1]))
+
+infix_term = Or([
+    e_bracket,
+    e_var,
+    e_lit,
+    e_neg,
+    e_op(ast.Log, "[log]"),
+    e_op(ast.Abs, "[abs]"),
+    e_op(ast.Floor, "[int]"),
+    e_op(ast.Exp, "[exp]"),
+    e_op(ast.Cos, "[cos]"),
+    e_op(ast.Sin, "[sin]"),
+    e_op(ast.Tan, "[tan]"),
+    e_binop(ast.Max, "[max]"),
+    e_binop(ast.Min, "[min]")
+])
+
+infix_nodes = {
+    "+": ast.Plus,
+    "-": ast.Minus,
+    "*": ast.Times,
+    "/": ast.Div,
+    "[mod": ast.Mod,
+    "^": ast.Pow
+}
+
+
+# pyparsing infixNotation helper has a strange behavior of grouping successive operands for a same operator into a
+# single group. For example parsing "1+2+3" will yield [1, '+', 2, '+', 3] instead of [[1, '+', 2], '+', 3]. This ugly
+# action reverses this kind of grouping. That ONLY happens for opAssoc.LEFT operations, so no need to handle pow case
+# See http://pyparsing.wikispaces.com/share/view/73472016
+def _infix_action(toks):
+    toks = toks[0]
+    assert len(toks) >= 3, toks
+    assert len(toks) % 2 == 1, "Expecting odd number of tokens"
+    op = toks[1]
+    result = infix_nodes[op](toks[0], toks[2])
+    remaining = toks[3:]
+    if not remaining:
+        return result
+    else:
+        return _infix_action([[result] + remaining])
+
+
+expr <<= infixNotation(infix_term, [
+    (oneOf('^'), 2, opAssoc.RIGHT, _infix_action),
+    (oneOf('* / [mod]'), 2, opAssoc.LEFT, _infix_action),
+    (oneOf('+ -'), 2, opAssoc.LEFT, _infix_action)
+])
+
+
+link_pat_linked = Suppress("!") + stok.copy().setParseAction(lambda toks: ast.Link(toks[0]))
+link_pat_bound = Suppress("!_").setParseAction(lambda _: ast.BoundLink)
+link_pat_mbound = Suppress("?").setParseAction(lambda _: ast.MaybeBoundLink)
+link_pat_unbound = Empty().setParseAction(lambda _: ast.UnboundLink)
+link_pat = link_pat_bound ^ link_pat_linked ^ link_pat_mbound ^ link_pat_unbound
+
+
+def site_pat_action(toks):
+    return toks.name, ast.SiteP(toks.link, ast.State(toks.state[0]) if toks.state else ast.UndefinedState)
+site_pat_st = Suppress("~") + stok
+site_pat_link_first = (tok("name") + link_pat("link") + site_pat_st("state")).setParseAction(site_pat_action)
+site_pat_state_first = (tok("name") + site_pat_st("state") + link_pat("link")).setParseAction(site_pat_action)
+site_pat_just_link = (tok("name") + link_pat("link")).setParseAction(site_pat_action)
+site_pat = site_pat_link_first ^ site_pat_state_first ^ site_pat_just_link
+
+agent_pat = And([tok,
+                 many_space, Suppress("("),
+                 Group(delimitedList(site_pat)),
+                 many_space, Suppress(")")]
+                ).setParseAction(lambda toks: ast.AgentP(toks[0], dict(list(toks[1]))))
+
+tok_expr = (expr + many_space + Suppress(":") + many_space + qtok).setParseAction(lambda ts: ast.TokE(ts[1], ts[0]))
+
+tok_exprs = many_space + Suppress("|") + many_space + delimitedList(tok_expr)
+
+pure_rule = And([
+    qtok("desc"),
+    many_space,
+    Group(delimitedList(agent_pat))("lhs_agents"),
+    Optional(tok_expr)("lhs_tokens"),
+    many_space, Suppress("->"), many_space,
+    Group(delimitedList(agent_pat))("rhs_agents"),
+    Optional(tok_expr)("rhs_tokens"),
+    many_space, Suppress("@"), many_space,
+    expr("rate")
+]).setParseAction(lambda ts: [ast.Rule(lhs=(ts.lhs_agents, ts.lhs_tokens),
+                                       rhs=(ts.rhs_agents, ts.rhs_tokens),
+                                       rate=ts.rate, desc=ts.desc[0])])
+
+bi_rule = And([
+    qtok("desc"),
+    many_space,
+    Group(delimitedList(agent_pat))("lhs_agents"),
+    Optional(tok_expr)("lhs_tokens"),
+    many_space, Suppress("<->"), many_space,
+    Group(delimitedList(agent_pat))("rhs_agents"),
+    Optional(tok_expr)("rhs_tokens"),
+    many_space, Suppress("@"), many_space,
+    expr("rate_forward"),
+    many_space, Suppress(","), many_space,
+    expr("rate_backward"),
+]).setParseAction(lambda ts: [ast.Rule(lhs=(ts.lhs_agents, ts.lhs_tokens),
+                                       rhs=(ts.rhs_agents, ts.rhs_tokens),
+                                       rate=ts.rate_forward, desc=ts.desc),
+                              ast.Rule(lhs=(ts.rhs_agents, ts.rhs_tokens),
+                                       rhs=(ts.lhs_agents, ts.lhs_tokens),
+                                       rate=ts.rate_backward, desc=ts.desc[0])])
+
+circ_rule = And([
+    qtok("desc"),
+    many_space,
+    Group(delimitedList(agent_pat))("lhs_agents"),
+    Optional(tok_expr)("lhs_tokens"),
+    many_space, Suppress("->"), many_space,
+    Group(delimitedList(agent_pat))("rhs_agents"),
+    Optional(tok_expr)("rhs_tokens"),
+    many_space, Suppress("@"), many_space,
+    expr("rate"),
+    many_space, Suppress("("), many_space,
+    expr("rate_c"),
+    many_space, Suppress(")")
+]).setParseAction(lambda ts: [ast.Rule(lhs=(ts.lhs_agents, ts.lhs_tokens),
+                                       rhs=(ts.rhs_agents, ts.rhs_tokens),
+                                       rate=ts.rate, rate_c=ts.rate_c, desc=ts.desc[0])])
+
+rule_pat = pure_rule ^ bi_rule ^ circ_rule
+
+rule_dec = rule_pat.copy().setParseAction(lambda ts: ast.RD(ts[0]))
+
+obs_dec = (Suppress("%obs:") + many_space + qtok + many_space + agent_pat).\
+    setParseAction(lambda ts: ast.OB(ast.Obs(ts[0], ts[1])))
+
+init_dec = (Suppress("%init:") + many_space + double + many_space + Group(delimitedList(agent_pat))).\
+    setParseAction(lambda ts: ast.IN(ast.Init(ts[0], ts[1])))
+
+rdf_line = (Suppress("#^ ") + CharsNotIn("\n") + lineEnd.suppress()).setParseAction(lambda ts: ast.RDF(ts[0]))
+
+statement = rdf_line ^ agent_dec ^ var_dec ^ tok_dec ^ rule_dec ^ obs_dec ^ init_dec
+
+kappa_parser = ZeroOrMore(eol) + ZeroOrMore(statement + ZeroOrMore(eol))

--- a/harness/pip-requirements.txt
+++ b/harness/pip-requirements.txt
@@ -1,1 +1,2 @@
 rdflib
+pyparsing


### PR DESCRIPTION
First working version of Kappa parser in Python. Pretty much straightforward port of Haskell parser with only addition of handling operations priorities and associativity for infix notation.
I tested it on all files in modular subdir and it worked with no obvious glitches.

I also took a liberty to make `kcomp.py` more PEP8 compatible.

I haven't worked yet on derivation of agent declarations based on patterns in rules. That would be the next step.
